### PR TITLE
Add in built target to force serial build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -63,6 +63,10 @@ SUBDIRS =\
 # Public make targets
 ###############################################################################
 
+# Force serial build even if -jX is supplied
+# https://www.gnu.org/software/make/manual/make.html#index-_002eNOTPARALLEL
+.NOTPARALLEL:
+
 all: verb.$(SUF) main-all tbx-all verb.all.end
 
 clean: verb.clean main-clean tbx-clean


### PR DESCRIPTION
A parallel build does not work. If a user installs using octave's `pkg build` command, it seems to attempt a parallel build using the Makefile, and this fails. So, this commit adds a directive to ensure that this makefile is processed serially, even if the -jX options are passed to make.