### PR TITLE
spm_BIDS.m DWI allows 'dir'

### DIFF
--- a/spm_BIDS.m
+++ b/spm_BIDS.m
@@ -505,7 +505,7 @@ if exist(pth,'dir')
 
         %-Diffusion imaging file
         %------------------------------------------------------------------
-        p = parse_filename(f{i}, {'sub','ses','acq','run', 'bval','bvec'});
+        p = parse_filename(f{i}, {'sub','ses','acq','run', 'dir', 'bval','bvec'});
         subject.dwi = [subject.dwi p];
 
         %-bval file


### PR DESCRIPTION
in the case of separate additional acquisitions AP/PA it currently fails, e.g. 
```
f =
{'/sub-048/dwi/sub-048_dir-AP_dwi.nii'}
{'/sub-048/dwi/sub-048_dir-PA_dwi.nii'}
{'/sub-048/dwi/sub-048_dwi.nii'       }
```

simply adding 'dir' does the job 